### PR TITLE
Don't do strange things if bz is only used to close the PR.

### DIFF
--- a/share/bz/close.sh
+++ b/share/bz/close.sh
@@ -43,8 +43,10 @@ close () {
   fi
 
   local d=$(_pr_dir $pr)
-  local port_dir=$(_port_from_pr $d)
-  (cd $PORTSDIR/$port_dir ; find . -name ".gitattributes" -delete)
+  if [ -f ${d}/pr ]; then
+    local port_dir=$(_port_from_pr $d)
+    (cd $PORTSDIR/$port_dir ; find . -name ".gitattributes" -delete)
+  fi
   rm -rf $d
 }
 


### PR DESCRIPTION
As a side note, I really don't see the point of bz removing .gitattributes files.
First, because it did not create them, second, because it's not saying it does so.

I only found out because bz close was taking a lot of time after it seemed to have done its jobs:

```
$ bz close -c "Fixed" 202121
 * Info: Using [FreeBSD] (https://bugs.freebsd.org/bugzilla/xmlrpc.cgi)
 * Info: Modified the following fields in bug 202121
 * Info: resolution  : removed
 * Info: resolution  : added FIXED
 * Info: status      : removed New
 * Info: status      : added Closed
grep: /tmp/mat/freebsd/202121/pr: No such file or directory
[long time here]
^C
$
```
